### PR TITLE
Extraction fixes and LZ decompression

### DIFF
--- a/cache_extract.py
+++ b/cache_extract.py
@@ -54,7 +54,7 @@ def handle_files(cache, toc, outdir):
 			"<qq4i64s", data
 		)
 		filename = filename.rstrip(b"\0").decode()
-		if timestamp == -1:
+		if timestamp == -1 or timestamp == 0:
 			file_time = None
 		else:
 			file_time = filetime.to_datetime(timestamp)
@@ -84,9 +84,10 @@ def handle_files(cache, toc, outdir):
 				assert entry.compressed_size == entry.size, "LZ not supported yet"
 				f.write(cache.read(entry.compressed_size))
 
-			# Set write time to the entry's filetime
-			ts = entry.time.timestamp()
-			os.utime(local_path, (ts, ts))
+			if entry.time:
+				# Set write time to the entry's filetime
+				ts = entry.time.timestamp()
+				os.utime(local_path, (ts, ts))
 
 
 def main():

--- a/cache_extract.py
+++ b/cache_extract.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
+import io
 import os
 import struct
 import sys
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, BinaryIO
 
 import filetime
 
@@ -34,6 +35,61 @@ class TOC:
 
 	def add_entry(self, entry: TOCEntry) -> None:
 		self.entries.append(entry)
+
+
+def lz_decompress(entry: TOCEntry, cache: BinaryIO) -> bytes:
+	out = io.BytesIO()
+
+	size = 0
+	while size < entry.size:
+		comp_len, decomp_len = struct.unpack(">HH", cache.read(4))
+		compressed = cache.read(comp_len)
+
+		if comp_len == decomp_len:
+			decompressed = compressed
+		else:
+			decompressed = b""
+			pos = 0
+			while pos < len(compressed):
+				code = compressed[pos]
+				pos += 1
+				if code <= 0x1f:
+					# literal string
+					assert pos + code < len(compressed), "Attempted to read past compressed buffer"
+					assert len(decompressed) + code < decomp_len, "Attempted to write past decompression buffer"
+					decompressed += compressed[pos:pos + code + 1]
+					pos += code + 1
+				else:
+					# dictionary entry
+					copylen = code >> 5
+					if copylen == 7:
+						# 7 or more bytes to copy
+						assert pos < len(compressed), "Attempted to read past compressed buffer"
+						copylen += compressed[pos]
+						pos += 1
+					copylen += 2
+
+					assert pos < len(compressed), "Attempted to read past compressed buffer"
+					lookback = ((code & 0x1f) << 8) | compressed[pos]
+					pos += 1
+
+					decomp_index = (len(decompressed) - 1) - lookback
+					assert decomp_index >= 0, "Attempted to read below decompression buffer"
+
+					# only do byte-by-byte copy if we have to (i.e. if we are reading and writing the same portion of the buffer)
+					if decomp_index + copylen > len(decompressed):
+						for i in range(decomp_index, decomp_index + copylen):
+							decompressed += decompressed[i:i + 1]
+					else:
+						decompressed += decompressed[decomp_index:decomp_index + copylen]
+
+		assert len(decompressed) == decomp_len, f"Did not decompress all bytes in chunk - Expected {decomp_len}, but decompressed was {len(decompressed)}"
+		out.write(decompressed)
+		size += decomp_len
+
+	assert size == entry.size, f"Expected to decompress to {entry.size} bytes, but decompressed to {size}"
+
+	return out.getvalue()
 
 
 def handle_files(cache, toc, outdir):
@@ -82,8 +138,10 @@ def handle_files(cache, toc, outdir):
 					os.makedirs(dirname)
 				with open(local_path, "wb") as f:
 					cache.seek(entry.offset)
-					assert entry.compressed_size == entry.size, "LZ not supported yet"
-					f.write(cache.read(entry.compressed_size))
+					if entry.compressed_size == entry.size:
+						f.write(cache.read(entry.compressed_size))
+					else:
+						f.write(lz_decompress(entry, cache))
 			except (FileNotFoundError, PermissionError) as e:
 				sys.stderr.write(f"Cannot write {entry.full_path} - {e.strerror}\n")
 			else:


### PR DESCRIPTION
- Fix crash when some files give 0 as their date (note that when extracted such files will use their extraction time as creation time)
- Fix for overlapping paths (see commit for more details)
- Implemented LZ decompression 
